### PR TITLE
Remove fatal error when template enumeration fails

### DIFF
--- a/src/main.vala
+++ b/src/main.vala
@@ -187,8 +187,7 @@ namespace Valdo.Main {
      */
     void enumerate_templates (File templates_dir,
                               HashTable<string, string> templates,
-                              ref int max_template_name_len,
-                              bool error_on_fail = false) {
+                              ref int max_template_name_len) {
         try {
             var enumerator = templates_dir.enumerate_children (
                 FileAttribute.ID_FILE,
@@ -212,12 +211,9 @@ namespace Valdo.Main {
                     max_template_name_len = template_name.length;
             }
         } catch (Error e) {
-            string error_message = "Can't enumerate templates: %s\n\n";
-            if (error_on_fail) {
-                error (error_message, e.message);
-            } else {
-                debug (error_message, e.message);
-            }
+            const string error_message = "Can't enumerate templates: %s\n\n";
+            debug (error_message, e.message);
+            return;
         }
     }
 
@@ -267,7 +263,7 @@ namespace Valdo.Main {
 
         int max_template_name_len = 0;
 
-        enumerate_templates (templates_dir, templates, ref max_template_name_len, true);
+        enumerate_templates (templates_dir, templates, ref max_template_name_len);
         enumerate_templates (custom_templates_dir, custom_templates, ref max_template_name_len);
 
         if (templates.length != 0) {


### PR DESCRIPTION
Actually if /usr/share... do not contains template, valdo stop

<img width="1561" height="126" alt="image" src="https://github.com/user-attachments/assets/34e02aee-3861-4f94-8437-36c908b3255e" />


with this patch it print a better comment if fail:
<img width="882" height="225" alt="image" src="https://github.com/user-attachments/assets/daddb4d3-67fa-443c-a5e0-39277b437e8d" />

I use my package-manager (no root) for install valdo, my template is only in my prefix :)